### PR TITLE
calling Breaks2Qf in ClearBreak to clear location list as well

### DIFF
--- a/autoload/gdb.vim
+++ b/autoload/gdb.vim
@@ -842,6 +842,7 @@ endfunction
 
 function! gdb#ClearBreak()
     let s:breakpoints = {}
+    call gdb#Breaks2Qf()
     call gdb#RefreshBreakpointSigns(0)
     call gdb#RefreshBreakpoints(2)
 endfunction


### PR DESCRIPTION
Normally, if I call ``GdbClearBreakpoints``, the location list ends up containing the old breakpoints, and it is only updated after I place another breakpoint. This behaviour is somewhat confusing, so I've added a call that clears the location list right away.