### PR TITLE
Improvements to customizability

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The file structure should be clear, just copy the github.vim into ~/.vim/plugin/
 
 ## Installing when using [Vundle](https://github.com/VundleVim/Vundle.vim)
 
-Add the following line to the plugins regions of ~/.vimrc:
+Add the following line to the plugins regions of ``~/.vimrc``:
 
 ```vim
 Plugin 'huawenyu/neogdb.vim'
@@ -96,7 +96,7 @@ Plugin 'huawenyu/neogdb.vim'
 
 # Customization
 
-Put these in your .vimrc to customize the keymaps:
+Put these in your ``~/.vimrc`` to customize the keymaps:
 
 ```vim
 let g:gdb_keymap_continue = '<f8>'
@@ -145,11 +145,11 @@ nmap <Space>p :call gdb#Send("print " . expand('<cword>'))<CR>
 You can run your own code when Neogdb sets its keymaps.  
 The plugin will call ``NeogdbvimNmapCallback`` on initialization and ``NeogdbvimUnmapCallback`` on exiting, if these functions exist.  
 
-For example, you can put this in your ``.vimrc``:
+For example, you can put this in your ``~/.vimrc``:
 
 ```vim
 function! NeogdbvimNmapCallback()
-    " Let fzf.vim open files in the current buffer by default.
+    " Let fzf.vim open files in the current window by default.
     " This is so that, when navigating files,
     " we don't switch to a new tab and thus *always* see the neogdb's splits. 
     let g:fzf_action = { 'enter': 'edit' }

--- a/README.md
+++ b/README.md
@@ -87,12 +87,80 @@ Plugin 'huawenyu/neogdb.vim'
   - :GdbEvalWord
   - :GdbWatchWord
 
-## Keys
+## Default keymaps
   - `<F4>` continue
   - `<F5>` next
   - `<F6>` step
   - `<F7>` finish
   - `<F9>` print <var>
+
+# Customization
+
+Put these in your .vimrc to customize the keymaps:
+
+```vim
+let g:gdb_keymap_continue = '<f8>'
+let g:gdb_keymap_next = '<f10>'
+let g:gdb_keymap_step = '<f11>'
+" Usually, F23 is just Shift+F11
+let g:gdb_keymap_finish = '<f23>'
+let g:gdb_keymap_toggle_break = '<f9>'
+" Usually, F33 is just Ctrl+F9
+let g:gdb_keymap_toggle_break_all = '<f33>'
+let g:gdb_keymap_frame_up = '<c-n>'
+let g:gdb_keymap_frame_down = '<c-p>'
+" Usually, F21 is just Shift+F9
+let g:gdb_keymap_clear_break = '<f21>'
+" Usually, F17 is just Shift+F5
+let g:gdb_keymap_debug_stop = '<f17>'
+```
+
+## Miscellaneous
+
+By default, if you run ``GdbLocal`` or ``GdbRemote`` when GDB is already started,  
+the plugin will send an interrupt (``<c-c>``) followed by a ``start``.  
+This is in order to speed up the edit-compile-test cycle.  
+If you instead want an error to be thrown when GDB is already started, change this variable:
+
+```vim
+let g:restart_app_if_gdb_running = 0
+```
+
+By default, the plugin toggles the breakpoint right after pressing ``g:gdb_keymap_toggle_break``.  
+If this flag is set to 1, the plugin will require you to confirm the command with Enter which lets you edit the command before issuing it:
+
+```vim
+let g:gdb_require_enter_after_toggling_breakpoint = 0
+```
+
+To send your own commands to GDB:
+
+```vim
+" Prints the value of the variable under the cursor
+nmap <Space>p :call gdb#Send("print " . expand('<cword>'))<CR>
+```
+
+### Map and unmap callbacks
+
+You can run your own code when Neogdb sets its keymaps.  
+The plugin will call ``NeogdbvimNmapCallback`` on initialization and ``NeogdbvimUnmapCallback`` on exiting, if these functions exist.  
+
+For example, you can put this in your ``.vimrc``:
+
+```vim
+function! NeogdbvimNmapCallback()
+    " Let fzf.vim open files in the current buffer by default.
+    " This is so that, when navigating files,
+    " we don't switch to a new tab and thus *always* see the neogdb's splits. 
+    let g:fzf_action = { 'enter': 'edit' }
+endfunc
+
+function! NeogdbvimUnmapCallback()
+    " Quitting to normal editing. Let fzf.vim open files in the new tab,
+    " as usual.
+    let g:fzf_action = { 'enter': 'tabnew' }
+endfunc
+```
 
 # License
 Vim license, see LICENSE

--- a/autoload/gdb.vim
+++ b/autoload/gdb.vim
@@ -942,6 +942,10 @@ if !exists("g:gdb_keymap_toggle_break_all")
     let g:gdb_keymap_toggle_break_all = '<f10>'
 endif
 
+if !exists("g:gdb_require_enter_after_toggling_breakpoint")
+    let g:gdb_require_enter_after_toggling_breakpoint = 0
+endif
+
 function! gdb#Map(type)
     "{
     if a:type ==# "unmap"
@@ -977,7 +981,15 @@ function! gdb#Map(type)
         exe 'nnoremap <silent> ' . g:gdb_keymap_step . ' :GdbStep<cr>'
         exe 'nnoremap <silent> ' . g:gdb_keymap_finish . ' :GdbFinish<cr>'
         exe 'nnoremap <silent> ' . g:gdb_keymap_until . ' :GdbUntil<cr>'
-        exe 'nnoremap <silent> ' . g:gdb_keymap_toggle_break . ' :GdbToggleBreak<cr>'
+
+		let toggle_break_binding = 'nnoremap <silent> ' . g:gdb_keymap_toggle_break . ' :GdbToggleBreak<cr>'
+
+		if !g:gdb_require_enter_after_toggling_breakpoint 
+			let toggle_break_binding = toggle_break_binding . '<cr>'
+		endif
+
+		exe toggle_break_binding
+
         exe 'nnoremap <silent> ' . g:gdb_keymap_toggle_break_all . ' :GdbToggleBreakAll<cr>'
         exe 'cnoremap <silent> ' . g:gdb_keymap_toggle_break . ' <cr>'
         exe 'vnoremap <silent> ' . g:gdb_keymap_toggle_break . ' :GdbEvalRange<cr>'

--- a/autoload/gdb.vim
+++ b/autoload/gdb.vim
@@ -372,7 +372,12 @@ endfunction
 
 function! gdb#Spawn(conf, ...)
     if exists('g:gdb')
-        throw 'Gdb already running'
+		if g:restart_app_if_gdb_running
+    		call jobsend(g:gdb._client_id, "\<c-c>info line\<cr>start\<cr>")
+			return	
+		else
+			throw 'Gdb already running'
+		endif
     endif
 
     let client_proc = (a:0 >= 1) ? a:1 : ''
@@ -916,6 +921,13 @@ function! gdb#Watch(expr)
     call gdb#Eval(expr)
     call gdb#Send('watch *$')
 endfunction
+
+" Other options
+if !exists("g:restart_app_if_gdb_running")
+    let g:restart_app_if_gdb_running = 1
+endif
+
+" Keymap options
 
 if !exists("g:gdb_keymap_refresh")
     let g:gdb_keymap_refresh = '<f3>'

--- a/autoload/gdb.vim
+++ b/autoload/gdb.vim
@@ -995,6 +995,10 @@ function! gdb#Map(type)
         exe 'tunmap ' . g:gdb_keymap_step
         exe 'tunmap ' . g:gdb_keymap_finish
         exe 'tunmap ' . g:gdb_keymap_toggle_break_all
+
+        if exists("*NeogdbvimUnmapCallback")
+            call NeogdbvimUnmapCallback()
+        endif
     elseif a:type ==# "tmap"
         exe 'tnoremap <silent> ' . g:gdb_keymap_refresh . ' <c-\><c-n>:GdbRefresh<cr>i'
         exe 'tnoremap <silent> ' . g:gdb_keymap_continue . ' <c-\><c-n>:GdbContinue<cr>i'
@@ -1025,6 +1029,10 @@ function! gdb#Map(type)
         exe 'nnoremap <silent> ' . g:gdb_keymap_debug_stop . ' :GdbDebugStop<cr>'
         exe 'nnoremap <silent> ' . g:gdb_keymap_frame_up . ' :GdbFrameUp<cr>'
         exe 'nnoremap <silent> ' . g:gdb_keymap_frame_down . ' :GdbFrameDown<cr>'
+
+        if exists("*NeogdbvimNmapCallback")
+            call NeogdbvimNmapCallback()
+        endif
     endif
     "}
 endfunction

--- a/autoload/gdb.vim
+++ b/autoload/gdb.vim
@@ -953,6 +953,12 @@ endif
 if !exists("g:gdb_keymap_toggle_break_all")
     let g:gdb_keymap_toggle_break_all = '<f10>'
 endif
+if !exists("g:gdb_keymap_toggle_break_all")
+	let g:gdb_keymap_clear_break = '<f21>'
+endif
+if !exists("g:gdb_keymap_debug_stop")
+	let g:gdb_keymap_debug_stop = '<f17>'
+endif
 
 if !exists("g:gdb_keymap_frame_up")
     let g:gdb_keymap_frame_up = '<c-n>'
@@ -974,6 +980,8 @@ function! gdb#Map(type)
         exe 'unmap ' . g:gdb_keymap_next
         exe 'unmap ' . g:gdb_keymap_step
         exe 'unmap ' . g:gdb_keymap_finish
+        exe 'unmap ' . g:gdb_keymap_clear_break
+        exe 'unmap ' . g:gdb_keymap_debug_stop
         exe 'unmap ' . g:gdb_keymap_until
         exe 'unmap ' . g:gdb_keymap_toggle_break
         exe 'unmap ' . g:gdb_keymap_toggle_break_all
@@ -1013,6 +1021,8 @@ function! gdb#Map(type)
         exe 'nnoremap <silent> ' . g:gdb_keymap_toggle_break_all . ' :GdbToggleBreakAll<cr>'
         exe 'cnoremap <silent> ' . g:gdb_keymap_toggle_break . ' <cr>'
         exe 'vnoremap <silent> ' . g:gdb_keymap_toggle_break . ' :GdbEvalRange<cr>'
+        exe 'nnoremap <silent> ' . g:gdb_keymap_clear_break . ' :GdbClearBreak<cr>'
+        exe 'nnoremap <silent> ' . g:gdb_keymap_debug_stop . ' :GdbDebugStop<cr>'
         exe 'nnoremap <silent> ' . g:gdb_keymap_frame_up . ' :GdbFrameUp<cr>'
         exe 'nnoremap <silent> ' . g:gdb_keymap_frame_down . ' :GdbFrameDown<cr>'
     endif

--- a/autoload/gdb.vim
+++ b/autoload/gdb.vim
@@ -372,12 +372,12 @@ endfunction
 
 function! gdb#Spawn(conf, ...)
     if exists('g:gdb')
-		if g:restart_app_if_gdb_running
-    		call jobsend(g:gdb._client_id, "\<c-c>info line\<cr>start\<cr>")
-			return	
-		else
-			throw 'Gdb already running'
-		endif
+        if g:restart_app_if_gdb_running
+            call jobsend(g:gdb._client_id, "\<c-c>info line\<cr>start\<cr>")
+            return    
+        else
+            throw 'Gdb already running'
+        endif
     endif
 
     let client_proc = (a:0 >= 1) ? a:1 : ''
@@ -954,10 +954,10 @@ if !exists("g:gdb_keymap_toggle_break_all")
     let g:gdb_keymap_toggle_break_all = '<f10>'
 endif
 if !exists("g:gdb_keymap_toggle_break_all")
-	let g:gdb_keymap_clear_break = '<f21>'
+    let g:gdb_keymap_clear_break = '<f21>'
 endif
 if !exists("g:gdb_keymap_debug_stop")
-	let g:gdb_keymap_debug_stop = '<f17>'
+    let g:gdb_keymap_debug_stop = '<f17>'
 endif
 
 if !exists("g:gdb_keymap_frame_up")
@@ -1014,13 +1014,13 @@ function! gdb#Map(type)
         exe 'nnoremap <silent> ' . g:gdb_keymap_finish . ' :GdbFinish<cr>'
         exe 'nnoremap <silent> ' . g:gdb_keymap_until . ' :GdbUntil<cr>'
 
-		let toggle_break_binding = 'nnoremap <silent> ' . g:gdb_keymap_toggle_break . ' :GdbToggleBreak<cr>'
+        let toggle_break_binding = 'nnoremap <silent> ' . g:gdb_keymap_toggle_break . ' :GdbToggleBreak<cr>'
 
-		if !g:gdb_require_enter_after_toggling_breakpoint 
-			let toggle_break_binding = toggle_break_binding . '<cr>'
-		endif
+        if !g:gdb_require_enter_after_toggling_breakpoint 
+            let toggle_break_binding = toggle_break_binding . '<cr>'
+        endif
 
-		exe toggle_break_binding
+        exe toggle_break_binding
 
         exe 'nnoremap <silent> ' . g:gdb_keymap_toggle_break_all . ' :GdbToggleBreakAll<cr>'
         exe 'cnoremap <silent> ' . g:gdb_keymap_toggle_break . ' <cr>'

--- a/autoload/gdb.vim
+++ b/autoload/gdb.vim
@@ -942,6 +942,14 @@ if !exists("g:gdb_keymap_toggle_break_all")
     let g:gdb_keymap_toggle_break_all = '<f10>'
 endif
 
+if !exists("g:gdb_keymap_frame_up")
+    let g:gdb_keymap_frame_up = '<c-n>'
+endif
+
+if !exists("g:gdb_keymap_frame_down")
+    let g:gdb_keymap_frame_down = '<c-p>'
+endif
+
 if !exists("g:gdb_require_enter_after_toggling_breakpoint")
     let g:gdb_require_enter_after_toggling_breakpoint = 0
 endif
@@ -959,8 +967,8 @@ function! gdb#Map(type)
         exe 'unmap ' . g:gdb_keymap_toggle_break_all
         exe 'vunmap ' . g:gdb_keymap_toggle_break
         exe 'cunmap ' . g:gdb_keymap_toggle_break
-        unmap <c-n>
-        unmap <c-p>
+        exe 'unmap ' . g:gdb_keymap_frame_up
+        exe 'unmap ' . g:gdb_keymap_frame_down
         exe 'tunmap ' . g:gdb_keymap_refresh
         exe 'tunmap ' . g:gdb_keymap_continue
         exe 'tunmap ' . g:gdb_keymap_next
@@ -993,8 +1001,8 @@ function! gdb#Map(type)
         exe 'nnoremap <silent> ' . g:gdb_keymap_toggle_break_all . ' :GdbToggleBreakAll<cr>'
         exe 'cnoremap <silent> ' . g:gdb_keymap_toggle_break . ' <cr>'
         exe 'vnoremap <silent> ' . g:gdb_keymap_toggle_break . ' :GdbEvalRange<cr>'
-        nnoremap <silent> <c-n> :GdbFrameUp<cr>
-        nnoremap <silent> <c-p> :GdbFrameDown<cr>
+        exe 'nnoremap <silent> ' . g:gdb_keymap_frame_up . ' :GdbFrameUp<cr>'
+        exe 'nnoremap <silent> ' . g:gdb_keymap_frame_down . ' :GdbFrameDown<cr>'
     endif
     "}
 endfunction


### PR DESCRIPTION
Looks like this awesome plugin will be my weapon of choice when dealing with ``gdb``.
I made some improvements that I've found necessary for my workflow.
The commits pretty much say all about it.

Apart from other additions, the only **default** behaviour that has changed is:
- By default, don't require Enter when toggling a breakpoint. *(there is a flag for this now)*
- By default, if there is already an existing GDB instance, then instead of throwing an error, ``gdb#Spawn`` sends interrupt (in case the application is running too) and a ``start`` command to that gdb instance. *(there is a flag for this now)*
  - This lets me keep the splits in place and just makes gdb reload the application if it has changed.
  - And this lets you have the same keymap for starting and restarting the session.

Otherwise everything should run just about the same.

Future work:
  - [ ] Some breakpoint signs do not get cleared when I call ``GdbClearBreak``. They disappear when I call ``sign unplace *`` but this messes up my GitGutter signs, so I guess it would be nice to fix this somehow.
 - [ ] ``README`` should at least make a mention of what ``confloc#me`` is. I had no idea where this function was located and what it did. It, however, contains a customization for the gdb command that is to be run, and I bet that this might be the first thing the users will be looking for.
 - [ ] Currently, to achieve the layout which is depicted in the ``README``, one needs to change the ``layout`` property to ``vsp`` in ``confloc#me``, and additionally have ``set splitright`` in their ``.vimrc``. This too, probably, should have a mention in the ``README``.
- [ ] It looks like ``GdbDebugStop`` always ends with an error. *(this was also the case before my pull request)*
  - [ ] After calling ``GdbDebugStop``, the keymaps are all unset properly, but subsequent calls ``GdbLocal`` do not map the keys again unless you completely restart Neovim. *(this was also the case before my pull request)*
 - [ ] A keymap for ``GdbInterrupt`` in normal mode?
- [ ] Let the keymap for ``F2`` not be hardcoded as well because it is a very useful key!

Last but not least, thank you for this great plugin.